### PR TITLE
HEALTH-624 Error while creating Analysis Specifications

### DIFF
--- a/bika/health/widgets/analysisspecificationwidget.py
+++ b/bika/health/widgets/analysisspecificationwidget.py
@@ -82,8 +82,8 @@ class AnalysisSpecificationPanicValidator:
         else:
             instance.REQUEST['validated'] = self.name
 
-        pmins = instance.REQUEST.get('minpanic', {})[0]
-        pmaxs = instance.REQUEST.get('maxpanic', {})[0]
+        pmins = instance.REQUEST.get('minpanic', [{}])[0]
+        pmaxs = instance.REQUEST.get('maxpanic', [{}])[0]
         uids = pmins.keys()
         for uid in uids:
             pmin = pmins.get(uid, '') == '' and '0' or pmins[uid]


### PR DESCRIPTION
```
Module ZPublisher.Publish, line 138, in publish
Module ZPublisher.mapply, line 77, in mapply
Module ZPublisher.Publish, line 48, in call_object
Module Products.CMFPlone.FactoryTool, line 478, in _call_
Module ZPublisher.mapply, line 77, in mapply
Module ZPublisher.Publish, line 48, in call_object
Module Products.CMFFormController.FSControllerPageTemplate, line 91, in _call_
Module Products.CMFFormController.BaseControllerPageTemplate, line 26, in _call
Module Products.CMFFormController.FormController, line 384, in validate
Module ZPublisher.mapply, line 77, in mapply
Module ZPublisher.Publish, line 48, in call_object
Module Products.CMFFormController.FSControllerValidator, line 58, in _call_
Module Products.CMFFormController.Script, line 145, in _call_
Module Products.CMFCore.FSPythonScript, line 127, in _call_
Module Shared.DC.Scripts.Bindings, line 322, in _call_
Module Shared.DC.Scripts.Bindings, line 359, in _bindAndExec
Module Products.PythonScripts.PythonScript, line 344, in _exec
Module script, line 6, in validate_base
<FSControllerValidator at /JollyLabs/validate_base used for /JollyLabs/bika_setup/bika_analysisspecs/portal_factory/AnalysisSpec/analysisspec.2016-07-13.8654770149>
Line 6
Module Products.Archetypes.BaseObject, line 509, in validate
Module Products.Archetypes.Schema, line 606, in validate
Module Products.ATExtensions.field.records, line 133, in validate
Module Products.ATExtensions.field.record, line 341, in validate
Module Products.ATExtensions.field.record, line 358, in validate_validators
Module bika.health.widgets.analysisspecificationwidget, line 85, in _call_
KeyError: 0
```